### PR TITLE
Fix infer URLs to change them depending on its version.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,7 @@ jobs:
           - os: ubuntu-latest
             version: latest
           - os: macos-latest
-            version: 1.0.0
-          # macos only support version 1.0.0
-          # - os: macos-13
-          #   version: latest
+            version: latest
     steps:
     - name: clone
       uses: actions/checkout@v4

--- a/install.sh
+++ b/install.sh
@@ -17,23 +17,31 @@ INFER_INSTALLDIR="${RUNNER_TOOL_CACHE:-${INFER_TEMPDIR}}/infer"
 mkdir -p "${INFER_INSTALLDIR}"
 
 install_osx() {
-    if [ ! -f "${INFER_INSTALLDIR}/infer-osx-${VERSION}/bin/infer" ]; then
+    ARCH="-arm64"
+    if [[${VERSION} == "v1.0.0"]]; then
+      ARCH=""
+    fi
+    if [ ! -f "${INFER_INSTALLDIR}/infer-osx${ARCH}-${VERSION}/bin/infer" ]; then
       cd "${INFER_INSTALLDIR}" || exit
-      (curl -sL "https://github.com/facebook/infer/releases/download/${VERSION}/infer-osx-${VERSION}.tar.xz" | tar -xvJ) || \
+      (curl -sL "https://github.com/facebook/infer/releases/download/${VERSION}/infer-osx${ARCH}-${VERSION}.tar.xz" | tar -xvJ) || \
         echo "installed=false" >> "${GITHUB_OUTPUT}"
     fi
-    if [ -f "${INFER_INSTALLDIR}/infer-osx-${VERSION}/bin/infer" ]; then
-      echo "${INFER_INSTALLDIR}/infer-osx-${VERSION}/bin" >>"${GITHUB_PATH}"
+    if [ -f "${INFER_INSTALLDIR}/infer-osx${ARCH}-${VERSION}/bin/infer" ]; then
+      echo "${INFER_INSTALLDIR}/infer-osx${ARCH}-${VERSION}/bin" >>"${GITHUB_PATH}"
       echo "installed=true" >> "${GITHUB_OUTPUT}"
     fi
 }
 
 install_linux() {
-    if [ ! -f "${INFER_INSTALLDIR}/infer-linux64-${VERSION}/bin/infer" ]; then
-      cd "${INFER_INSTALLDIR}" || exit
-      curl -sL "https://github.com/facebook/infer/releases/download/${VERSION}/infer-linux64-${VERSION}.tar.xz" | tar -xJ
+    ARCH="-x86_64"
+    if [[${VERSION} == "v1.0.0"]] || [[${VERSION} == "v1.1.0"]]; then
+      ARCH="64"
     fi
-    echo "${INFER_INSTALLDIR}/infer-linux64-${VERSION}/bin" >>"${GITHUB_PATH}"
+    if [ ! -f "${INFER_INSTALLDIR}/infer-linux${ARCH}-${VERSION}/bin/infer" ]; then
+      cd "${INFER_INSTALLDIR}" || exit
+      curl -sL "https://github.com/facebook/infer/releases/download/${VERSION}/infer-linux${ARCH}-${VERSION}.tar.xz" | tar -xJ
+    fi
+    echo "${INFER_INSTALLDIR}/infer-linux${ARCH}-${VERSION}/bin" >>"${GITHUB_PATH}"
     echo "installed=true" >> "${GITHUB_OUTPUT}"
 }
 


### PR DESCRIPTION
Hi,

I found a bug that `setup-infer` couldn't download `infer` v.1.2.0 because the file name pattern of this release has changed. I fixed this bug by fixing `install.sh` to switch `curl` commands corresponding to `infer` version, and enabled `self-test` for the latest version on macOS.