### PR TITLE
Fix install.sh to have surrounding spaces in conditional statement

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ mkdir -p "${INFER_INSTALLDIR}"
 
 install_osx() {
     ARCH="-arm64"
-    if [[${VERSION} == "v1.0.0"]]; then
+    if [[ ${VERSION} == "v1.0.0" ]]; then
       ARCH=""
     fi
     if [ ! -f "${INFER_INSTALLDIR}/infer-osx${ARCH}-${VERSION}/bin/infer" ]; then
@@ -34,7 +34,7 @@ install_osx() {
 
 install_linux() {
     ARCH="-x86_64"
-    if [[${VERSION} == "v1.0.0"]] || [[${VERSION} == "v1.1.0"]]; then
+    if [[ ${VERSION} == "v1.0.0" ]] || [[ ${VERSION} == "v1.1.0" ]]; then
       ARCH="64"
     fi
     if [ ! -f "${INFER_INSTALLDIR}/infer-linux${ARCH}-${VERSION}/bin/infer" ]; then


### PR DESCRIPTION
At this moment, running setup-infer with no option on ubuntu-latest causes the following error:
```
  /home/runner/work/_actions/srz-zumix/setup-infer/b14c989788d6b5fb4003e910f642b6afd48a7ad3/install.sh: line 37: [[v1.2.0: command not found
  /home/runner/work/_actions/srz-zumix/setup-infer/b14c989788d6b5fb4003e910f642b6afd48a7ad3/install.sh: line 37: [[v1.2.0: command not found
```

Bash `[[ expression ]]` statement needs spaces surrounding the expression. This PR fixes all `[[ expression ]]` s.